### PR TITLE
プロンプトからterraform_exampleフィールドを削除

### DIFF
--- a/src/analysis/prompt_generator.py
+++ b/src/analysis/prompt_generator.py
@@ -74,8 +74,7 @@ AWSのTerraformコードの可用性を評価してください。AWS Well-Archi
   "recommendations": [
     {{
       "priority": "高/中/低",
-      "description": "推奨事項の詳細説明",
-      "terraform_example": "実装例（Terraformコード）"
+      "description": "推奨事項の詳細説明"
     }}
   ]
 }}
@@ -122,8 +121,7 @@ Please provide your analysis in the following JSON format:
   "recommendations": [
     {{
       "priority": "high/medium/low",
-      "description": "Detailed description of the recommendation",
-      "terraform_example": "Implementation example (Terraform code)"
+      "description": "Detailed description of the recommendation"
     }}
   ]
 }}


### PR DESCRIPTION
レスポンスのrecommendationsセクションからterraform_exampleフィールドを削除しました。これにより、AIがTerraformコードの例を生成する必要がなくなります。