### PR TITLE
Terraformのバックエンドをローカルへ変更

### DIFF
--- a/custom_output/temp.html
+++ b/custom_output/temp.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AWS Terraform可用性分析レポート</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        header {
+            background-color: #0066cc;
+            color: white;
+            padding: 20px;
+            border-radius: 5px;
+            margin-bottom: 20px;
+        }
+        h1, h2, h3 {
+            margin-top: 0;
+        }
+        .score-container {
+            text-align: center;
+            margin: 30px 0;
+        }
+        .score {
+            font-size: 48px;
+            font-weight: bold;
+        }
+        .score-high {
+            color: #28a745;
+        }
+        .score-medium {
+            color: #ffc107;
+        }
+        .score-low {
+            color: #dc3545;
+        }
+        .overview {
+            background-color: #f8f9fa;
+            border-left: 5px solid #0066cc;
+            padding: 15px;
+            margin-bottom: 30px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 30px;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 12px;
+            text-align: left;
+        }
+        th {
+            background-color: #f2f2f2;
+        }
+        tr:nth-child(even) {
+            background-color: #f9f9f9;
+        }
+        .severity-high, .priority-high {
+            color: #dc3545;
+            font-weight: bold;
+        }
+        .severity-medium, .priority-medium {
+            color: #ffc107;
+            font-weight: bold;
+        }
+        .severity-low, .priority-low {
+            color: #28a745;
+            font-weight: bold;
+        }
+        .recommendation {
+            background-color: #f8f9fa;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            padding: 15px;
+            margin-bottom: 20px;
+        }
+        .recommendation h3 {
+            margin-top: 0;
+            border-bottom: 2px solid #0066cc;
+            padding-bottom: 10px;
+        }
+        pre {
+            background-color: #f5f5f5;
+            padding: 15px;
+            border-radius: 5px;
+            overflow-x: auto;
+        }
+        footer {
+            margin-top: 50px;
+            text-align: center;
+            color: #777;
+            font-size: 0.9em;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>AWS Terraform可用性分析レポート</h1>
+        <p>AWS Well-Architected Frameworkの信頼性の柱に基づく評価</p>
+    </header>
+
+    <div class="score-container">
+        <h2>可用性スコア</h2>
+        <div class="score score-medium">65/100</div>
+    </div>
+
+    <section>
+        <h2>概要</h2>
+        <div class="overview">
+            <p>The infrastructure has some good practices in place for availability, such as multi-AZ deployment for certain resources and the use of WAF. However, there are several areas where improvements can be made to enhance overall reliability and availability.</p>
+        </div>
+    </section>
+
+    <section>
+        <h2>検出された問題点</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>カテゴリ</th>
+                    <th>重要度</th>
+                    <th>説明</th>
+                    <th>推奨対応</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>Multi-AZ</td>
+                    <td class="severity-medium">medium</td>
+                    <td>The VPC is configured with public and private subnets across two Availability Zones, which is good for high availability. However, some resources like DynamoDB and Lambda functions may not be fully utilizing this multi-AZ setup.</td>
+                    <td>Ensure that DynamoDB is configured for global tables or enable cross-region replication. Configure Lambda functions to run in multiple AZs.</td>
+                </tr>
+
+                <tr>
+                    <td>SPOF</td>
+                    <td class="severity-high">high</td>
+                    <td>The API Gateway and Lambda function could be potential single points of failure. There's no clear indication of redundancy or failover mechanisms for these critical components.</td>
+                    <td>Implement API Gateway regional endpoints and consider using AWS Global Accelerator for improved availability. Use Lambda provisioned concurrency to ensure capacity.</td>
+                </tr>
+
+                <tr>
+                    <td>Load Balancer</td>
+                    <td class="severity-high">high</td>
+                    <td>There is no Application Load Balancer (ALB) or Network Load Balancer (NLB) configured, which could improve the distribution of incoming traffic and provide better fault tolerance.</td>
+                    <td>Implement an Application Load Balancer in front of the API Gateway to improve traffic distribution and fault tolerance.</td>
+                </tr>
+
+                <tr>
+                    <td>Auto Scaling</td>
+                    <td class="severity-medium">medium</td>
+                    <td>There's no explicit auto-scaling configuration for the Lambda functions or DynamoDB, which could lead to performance issues during high traffic periods.</td>
+                    <td>Implement auto-scaling for Lambda functions using provisioned concurrency. Configure DynamoDB auto-scaling for read and write capacity units.</td>
+                </tr>
+
+                <tr>
+                    <td>Backup and Recovery</td>
+                    <td class="severity-medium">medium</td>
+                    <td>While DynamoDB has point-in-time recovery enabled, there's no clear backup strategy for other data stores like S3.</td>
+                    <td>Implement regular backups for S3 buckets using cross-region replication or S3 batch operations for periodic backups.</td>
+                </tr>
+
+                <tr>
+                    <td>Timeout and Retry</td>
+                    <td class="severity-low">low</td>
+                    <td>Lambda functions have a timeout set, but there's no clear retry mechanism for failed operations.</td>
+                    <td>Implement retry logic in Lambda functions for transient failures. Consider using Step Functions for complex workflows that require robust error handling and retries.</td>
+                </tr>
+
+            </tbody>
+        </table>
+    </section>
+
+    <section>
+        <h2>改善推奨事項</h2>
+
+        <div class="recommendation">
+            <h3>推奨事項 1: <span class="severity-high">優先度: high</span></h3>
+            <p>Implement an Application Load Balancer in front of the API Gateway to improve traffic distribution and fault tolerance. This will also help in handling potential spikes in traffic.</p>
+
+        </div>
+
+        <div class="recommendation">
+            <h3>推奨事項 2: <span class="severity-high">優先度: high</span></h3>
+            <p>Configure Lambda functions to run in multiple AZs and implement auto-scaling using provisioned concurrency to handle varying loads efficiently.</p>
+
+        </div>
+
+        <div class="recommendation">
+            <h3>推奨事項 3: <span class="severity-medium">優先度: medium</span></h3>
+            <p>Enable DynamoDB global tables or cross-region replication to improve data availability and disaster recovery capabilities.</p>
+
+        </div>
+
+        <div class="recommendation">
+            <h3>推奨事項 4: <span class="severity-medium">優先度: medium</span></h3>
+            <p>Implement a comprehensive backup strategy for all data stores, including S3 buckets, using cross-region replication or periodic backups.</p>
+
+        </div>
+
+        <div class="recommendation">
+            <h3>推奨事項 5: <span class="severity-low">優先度: low</span></h3>
+            <p>Enhance error handling and implement retry mechanisms in Lambda functions to improve resilience against transient failures.</p>
+
+        </div>
+
+    </section>
+
+    <footer>
+        <p>レポート生成: AWS Terraform可用性チェックツール</p>
+    </footer>
+</body>
+</html>

--- a/custom_output/terraform_plan.json
+++ b/custom_output/terraform_plan.json
@@ -1,0 +1,2846 @@
+{
+  "archive_file": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/main.tf",
+        "label": "archive_file",
+        "line_end": 34,
+        "line_start": 4,
+        "path": "module.lambda.data.archive_file.lambda_code",
+        "type": "data"
+      },
+      "id": "e67463d5-370f-4070-b6ac-3c7602da2544",
+      "output_path": "../../modules/lambda/lambda_function.zip",
+      "source": {
+        "__tfmeta": {
+          "filename": "../../modules/lambda/main.tf",
+          "line_end": 33,
+          "line_start": 8
+        },
+        "content": "exports.handler = async (event) => {\n  console.log('Event: ', JSON.stringify(event, null, 2));\n  \n  // DynamoDB\u304b\u3089\u30c7\u30fc\u30bf\u3092\u53d6\u5f97\u3059\u308b\u30b5\u30f3\u30d7\u30eb\u30b3\u30fc\u30c9\n  // const AWS = require('aws-sdk');\n  // const dynamodb = new AWS.DynamoDB.DocumentClient();\n  \n  // S3\u306b\u30c7\u30fc\u30bf\u3092\u4fdd\u5b58\u3059\u308b\u30b5\u30f3\u30d7\u30eb\u30b3\u30fc\u30c9\n  // const s3 = new AWS.S3();\n  \n  return {\n    statusCode: 200,\n    headers: {\n      'Content-Type': 'application/json'\n    },\n    body: JSON.stringify({\n      message: 'Hello from Lambda!',\n      timestamp: new Date().toISOString()\n    })\n  };\n};\n",
+        "filename": "index.js",
+        "id": "091a2b68-abab-4a85-9e2f-427ed8c8ed8c"
+      },
+      "type": "zip"
+    }
+  ],
+  "aws_api_gateway_deployment": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/main.tf",
+        "label": "aws_api_gateway_deployment",
+        "line_end": 59,
+        "line_start": 49,
+        "path": "module.api_gateway.aws_api_gateway_deployment.this",
+        "type": "resource"
+      },
+      "depends_on": {
+        "__attributes__": [
+          "aws_api_gateway_integration.this"
+        ],
+        "__name__": "this",
+        "__ref__": "304fe2a3-ac2b-40da-908e-b9bdff156afd",
+        "__type__": "aws_api_gateway_integration"
+      },
+      "id": "9f43f402-763c-4c53-8d59-576435dbf486",
+      "lifecycle": {
+        "__tfmeta": {
+          "filename": "../../modules/api_gateway/main.tf",
+          "line_end": 58,
+          "line_start": 56
+        },
+        "create_before_destroy": true,
+        "id": "8b9e3525-b257-43d2-b140-9a01d6b9c96c"
+      },
+      "rest_api_id": {
+        "__attribute__": "aws_api_gateway_rest_api.this.id",
+        "__name__": "this",
+        "__ref__": "1c193eca-1be1-49b4-b42c-ab26d6f64710",
+        "__type__": "aws_api_gateway_rest_api"
+      }
+    }
+  ],
+  "aws_api_gateway_integration": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/main.tf",
+        "label": "aws_api_gateway_integration",
+        "line_end": 44,
+        "line_start": 37,
+        "path": "module.api_gateway.aws_api_gateway_integration.this",
+        "type": "resource"
+      },
+      "http_method": {
+        "__attribute__": "aws_api_gateway_method.this.http_method",
+        "__name__": "this",
+        "__ref__": "2a811561-3a0d-42c6-a2fa-6dd5872e8996",
+        "__type__": "aws_api_gateway_method"
+      },
+      "id": "304fe2a3-ac2b-40da-908e-b9bdff156afd",
+      "integration_http_method": "POST",
+      "resource_id": {
+        "__attribute__": "aws_api_gateway_resource.this.id",
+        "__name__": "this",
+        "__ref__": "e9527718-b46e-4bc9-8448-f68add287afb",
+        "__type__": "aws_api_gateway_resource"
+      },
+      "rest_api_id": {
+        "__attribute__": "aws_api_gateway_rest_api.this.id",
+        "__name__": "this",
+        "__ref__": "1c193eca-1be1-49b4-b42c-ab26d6f64710",
+        "__type__": "aws_api_gateway_rest_api"
+      },
+      "type": "AWS_PROXY",
+      "uri": null
+    }
+  ],
+  "aws_api_gateway_method": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/main.tf",
+        "label": "aws_api_gateway_method",
+        "line_end": 32,
+        "line_start": 27,
+        "path": "module.api_gateway.aws_api_gateway_method.this",
+        "type": "resource"
+      },
+      "authorization": "NONE",
+      "http_method": "ANY",
+      "id": "2a811561-3a0d-42c6-a2fa-6dd5872e8996",
+      "resource_id": {
+        "__attribute__": "aws_api_gateway_resource.this.id",
+        "__name__": "this",
+        "__ref__": "e9527718-b46e-4bc9-8448-f68add287afb",
+        "__type__": "aws_api_gateway_resource"
+      },
+      "rest_api_id": {
+        "__attribute__": "aws_api_gateway_rest_api.this.id",
+        "__name__": "this",
+        "__ref__": "1c193eca-1be1-49b4-b42c-ab26d6f64710",
+        "__type__": "aws_api_gateway_rest_api"
+      }
+    }
+  ],
+  "aws_api_gateway_method_settings": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/main.tf",
+        "label": "aws_api_gateway_method_settings",
+        "line_end": 86,
+        "line_start": 77,
+        "path": "module.api_gateway.aws_api_gateway_method_settings.this",
+        "type": "resource"
+      },
+      "id": "58695458-edf3-4ff5-afae-7adce6930974",
+      "method_path": "*/*",
+      "rest_api_id": {
+        "__attribute__": "aws_api_gateway_rest_api.this.id",
+        "__name__": "this",
+        "__ref__": "1c193eca-1be1-49b4-b42c-ab26d6f64710",
+        "__type__": "aws_api_gateway_rest_api"
+      },
+      "settings": {
+        "__tfmeta": {
+          "filename": "../../modules/api_gateway/main.tf",
+          "line_end": 85,
+          "line_start": 82
+        },
+        "id": "9583470b-7c64-4340-b969-fedaf20db5d4",
+        "logging_level": "INFO",
+        "metrics_enabled": true
+      },
+      "stage_name": {
+        "__attribute__": "aws_api_gateway_stage.this.stage_name",
+        "__name__": "this",
+        "__ref__": "30b559df-cdf8-49cf-b6c5-af082436771c",
+        "__type__": "aws_api_gateway_stage"
+      }
+    }
+  ],
+  "aws_api_gateway_resource": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/main.tf",
+        "label": "aws_api_gateway_resource",
+        "line_end": 22,
+        "line_start": 18,
+        "path": "module.api_gateway.aws_api_gateway_resource.this",
+        "type": "resource"
+      },
+      "id": "e9527718-b46e-4bc9-8448-f68add287afb",
+      "parent_id": {
+        "__attribute__": "aws_api_gateway_rest_api.this.root_resource_id",
+        "__name__": "this",
+        "__ref__": "1c193eca-1be1-49b4-b42c-ab26d6f64710",
+        "__type__": "aws_api_gateway_rest_api"
+      },
+      "path_part": "api",
+      "rest_api_id": {
+        "__attribute__": "aws_api_gateway_rest_api.this.id",
+        "__name__": "this",
+        "__ref__": "1c193eca-1be1-49b4-b42c-ab26d6f64710",
+        "__type__": "aws_api_gateway_rest_api"
+      }
+    }
+  ],
+  "aws_api_gateway_rest_api": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/main.tf",
+        "label": "aws_api_gateway_rest_api",
+        "line_end": 13,
+        "line_start": 4,
+        "path": "module.api_gateway.aws_api_gateway_rest_api.this",
+        "type": "resource"
+      },
+      "description": "API Gateway for serverless-app dev",
+      "endpoint_configuration": {
+        "__tfmeta": {
+          "filename": "../../modules/api_gateway/main.tf",
+          "line_end": 10,
+          "line_start": 8
+        },
+        "id": "bf2bc410-08ff-41df-a3d0-27c7b60d3595",
+        "types": [
+          "REGIONAL"
+        ]
+      },
+      "id": "1c193eca-1be1-49b4-b42c-ab26d6f64710",
+      "name": "serverless-app-dev-api",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    }
+  ],
+  "aws_api_gateway_stage": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/main.tf",
+        "label": "aws_api_gateway_stage",
+        "line_end": 72,
+        "line_start": 64,
+        "path": "module.api_gateway.aws_api_gateway_stage.this",
+        "type": "resource"
+      },
+      "deployment_id": {
+        "__attribute__": "aws_api_gateway_deployment.this.id",
+        "__name__": "this",
+        "__ref__": "9f43f402-763c-4c53-8d59-576435dbf486",
+        "__type__": "aws_api_gateway_deployment"
+      },
+      "id": "30b559df-cdf8-49cf-b6c5-af082436771c",
+      "rest_api_id": {
+        "__attribute__": "aws_api_gateway_rest_api.this.id",
+        "__name__": "this",
+        "__ref__": "1c193eca-1be1-49b4-b42c-ab26d6f64710",
+        "__type__": "aws_api_gateway_rest_api"
+      },
+      "stage_name": "dev",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "xray_tracing_enabled": true
+    }
+  ],
+  "aws_availability_zones": [
+    {
+      "__tfmeta": {
+        "filename": "data.tf",
+        "label": "aws_availability_zones",
+        "line_end": 7,
+        "line_start": 5,
+        "path": "data.aws_availability_zones.available",
+        "type": "data"
+      },
+      "id": "585617d9-fdaa-4d2d-8d2a-469237faf227",
+      "state": "available"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_availability_zones",
+        "line_end": 170,
+        "line_start": 168,
+        "path": "module.vpc.data.aws_availability_zones.available",
+        "type": "data"
+      },
+      "id": "50ce2412-e2a1-4ada-8b4c-5810d12c6ff2",
+      "state": "available"
+    }
+  ],
+  "aws_caller_identity": [
+    {
+      "__tfmeta": {
+        "filename": "data.tf",
+        "label": "aws_caller_identity",
+        "line_end": 1,
+        "line_start": 1,
+        "path": "data.aws_caller_identity.current",
+        "type": "data"
+      },
+      "id": "49b2e017-49db-47ef-a421-87252be2078d"
+    }
+  ],
+  "aws_cloudwatch_log_group": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/main.tf",
+        "label": "aws_cloudwatch_log_group",
+        "line_end": 107,
+        "line_start": 102,
+        "path": "module.lambda.aws_cloudwatch_log_group.lambda",
+        "type": "resource"
+      },
+      "id": "d940324d-51eb-4321-99c7-1baef6525de1",
+      "name": {
+        "__attribute__": "aws_lambda_function.this.function_name",
+        "__name__": "this",
+        "__ref__": "a2e43157-2906-40d6-ac61-8c8f38893ba4",
+        "__type__": "aws_lambda_function"
+      },
+      "retention_in_days": 14,
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    }
+  ],
+  "aws_dynamodb_table": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/dynamodb/main.tf",
+        "label": "aws_dynamodb_table",
+        "line_end": 31,
+        "line_start": 4,
+        "path": "module.dynamodb.aws_dynamodb_table.this",
+        "type": "resource"
+      },
+      "attribute": {
+        "__tfmeta": {
+          "filename": "../../modules/dynamodb/main.tf",
+          "line_end": 15,
+          "line_start": 12
+        },
+        "id": "75ea0540-601f-47ad-98cd-214790eecdad",
+        "name": "id",
+        "type": "S"
+      },
+      "billing_mode": "PROVISIONED",
+      "hash_key": "id",
+      "id": "4915aa85-409d-4771-b1c2-dde27e1deb1d",
+      "name": "serverless-app-dev-data",
+      "point_in_time_recovery": {
+        "__tfmeta": {
+          "filename": "../../modules/dynamodb/main.tf",
+          "line_end": 19,
+          "line_start": 17
+        },
+        "enabled": true,
+        "id": "c4882207-3d96-49a4-9c7c-294b75d45cef"
+      },
+      "read_capacity": 5,
+      "server_side_encryption": {
+        "__tfmeta": {
+          "filename": "../../modules/dynamodb/main.tf",
+          "line_end": 23,
+          "line_start": 21
+        },
+        "enabled": true,
+        "id": "9b99ddf4-23d4-433c-b4e8-9f60cdae576b"
+      },
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-data",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "write_capacity": 5
+    }
+  ],
+  "aws_eip": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_eip",
+        "line_end": 77,
+        "line_start": 67,
+        "path": "module.vpc.aws_eip.nat[0]",
+        "type": "resource"
+      },
+      "count": 2,
+      "domain": "vpc",
+      "id": "b1b9856a-37cf-4bf9-b985-7a1ea1c344eb",
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-nat-eip-1",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_eip",
+        "line_end": 77,
+        "line_start": 67,
+        "path": "module.vpc.aws_eip.nat[1]",
+        "type": "resource"
+      },
+      "count": 2,
+      "domain": "vpc",
+      "id": "0c747ead-bad3-4b69-84ad-5fea56c08c8a",
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-nat-eip-2",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    }
+  ],
+  "aws_iam_policy": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/iam/main.tf",
+        "label": "aws_iam_policy",
+        "line_end": 55,
+        "line_start": 26,
+        "path": "module.iam.aws_iam_policy.lambda_basic",
+        "type": "resource"
+      },
+      "description": "Basic policy for Lambda functions",
+      "id": "20036c59-42c3-46a6-a90f-342d3c3c43a8",
+      "name": "serverless-app-dev-lambda-basic-policy",
+      "policy": "{\"Statement\":[{\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Effect\":\"Allow\",\"Resource\":\"*\"},{\"Action\":[\"ec2:CreateNetworkInterface\",\"ec2:DescribeNetworkInterfaces\",\"ec2:DeleteNetworkInterface\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/iam/main.tf",
+        "label": "aws_iam_policy",
+        "line_end": 83,
+        "line_start": 60,
+        "path": "module.iam.aws_iam_policy.lambda_dynamodb",
+        "type": "resource"
+      },
+      "description": "Policy for Lambda functions to access DynamoDB",
+      "id": "d1b2626b-e7f4-44d7-9990-2f6ecd52e18c",
+      "name": "serverless-app-dev-lambda-dynamodb-policy",
+      "policy": "{\"Statement\":[{\"Action\":[\"dynamodb:GetItem\",\"dynamodb:PutItem\",\"dynamodb:UpdateItem\",\"dynamodb:DeleteItem\",\"dynamodb:Query\",\"dynamodb:Scan\"],\"Effect\":\"Allow\",\"Resource\":\"arn:aws:dynamodb:*:*:table/serverless-app-dev-*\"}],\"Version\":\"2012-10-17\"}",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/iam/main.tf",
+        "label": "aws_iam_policy",
+        "line_end": 112,
+        "line_start": 88,
+        "path": "module.iam.aws_iam_policy.lambda_s3",
+        "type": "resource"
+      },
+      "description": "Policy for Lambda functions to access S3",
+      "id": "acb1529d-c7cf-427b-9364-19da4d2e4671",
+      "name": "serverless-app-dev-lambda-s3-policy",
+      "policy": "{\"Statement\":[{\"Action\":[\"s3:GetObject\",\"s3:PutObject\",\"s3:DeleteObject\",\"s3:ListBucket\"],\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:s3:::serverless-app-dev-*\",\"arn:aws:s3:::serverless-app-dev-*/*\"]}],\"Version\":\"2012-10-17\"}",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    }
+  ],
+  "aws_iam_role": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/iam/main.tf",
+        "label": "aws_iam_role",
+        "line_end": 21,
+        "line_start": 4,
+        "path": "module.iam.aws_iam_role.lambda",
+        "type": "resource"
+      },
+      "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+      "id": "307d8b4e-af59-4745-8a1b-969016359af3",
+      "name": "serverless-app-dev-lambda-role",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    }
+  ],
+  "aws_iam_role_policy_attachment": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/iam/main.tf",
+        "label": "aws_iam_role_policy_attachment",
+        "line_end": 120,
+        "line_start": 117,
+        "path": "module.iam.aws_iam_role_policy_attachment.lambda_basic",
+        "type": "resource"
+      },
+      "id": "3ec94b50-e677-4ab0-b665-264f1c19b2a1",
+      "policy_arn": {
+        "__attribute__": "aws_iam_policy.lambda_basic.arn",
+        "__name__": "lambda_basic",
+        "__ref__": "20036c59-42c3-46a6-a90f-342d3c3c43a8",
+        "__type__": "aws_iam_policy"
+      },
+      "role": {
+        "__attribute__": "aws_iam_role.lambda.name",
+        "__name__": "lambda",
+        "__ref__": "307d8b4e-af59-4745-8a1b-969016359af3",
+        "__type__": "aws_iam_role"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/iam/main.tf",
+        "label": "aws_iam_role_policy_attachment",
+        "line_end": 125,
+        "line_start": 122,
+        "path": "module.iam.aws_iam_role_policy_attachment.lambda_dynamodb",
+        "type": "resource"
+      },
+      "id": "da0e149e-6e47-4912-b5ee-d36157074869",
+      "policy_arn": {
+        "__attribute__": "aws_iam_policy.lambda_dynamodb.arn",
+        "__name__": "lambda_dynamodb",
+        "__ref__": "d1b2626b-e7f4-44d7-9990-2f6ecd52e18c",
+        "__type__": "aws_iam_policy"
+      },
+      "role": {
+        "__attribute__": "aws_iam_role.lambda.name",
+        "__name__": "lambda",
+        "__ref__": "307d8b4e-af59-4745-8a1b-969016359af3",
+        "__type__": "aws_iam_role"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/iam/main.tf",
+        "label": "aws_iam_role_policy_attachment",
+        "line_end": 130,
+        "line_start": 127,
+        "path": "module.iam.aws_iam_role_policy_attachment.lambda_s3",
+        "type": "resource"
+      },
+      "id": "469cea94-d920-40fe-ae65-e928df54853b",
+      "policy_arn": {
+        "__attribute__": "aws_iam_policy.lambda_s3.arn",
+        "__name__": "lambda_s3",
+        "__ref__": "acb1529d-c7cf-427b-9364-19da4d2e4671",
+        "__type__": "aws_iam_policy"
+      },
+      "role": {
+        "__attribute__": "aws_iam_role.lambda.name",
+        "__name__": "lambda",
+        "__ref__": "307d8b4e-af59-4745-8a1b-969016359af3",
+        "__type__": "aws_iam_role"
+      }
+    }
+  ],
+  "aws_internet_gateway": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_internet_gateway",
+        "line_end": 62,
+        "line_start": 53,
+        "path": "module.vpc.aws_internet_gateway.this",
+        "type": "resource"
+      },
+      "id": "c4fc88be-84bf-4e9d-85e1-5b3269e64d91",
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-igw",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "vpc_id": {
+        "__attribute__": "aws_vpc.this.id",
+        "__name__": "this",
+        "__ref__": "412261b3-d02a-4504-9127-abe62236d13e",
+        "__type__": "aws_vpc"
+      }
+    }
+  ],
+  "aws_lambda_function": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/main.tf",
+        "label": "aws_lambda_function",
+        "line_end": 64,
+        "line_start": 39,
+        "path": "module.lambda.aws_lambda_function.this",
+        "type": "resource"
+      },
+      "environment": {
+        "__tfmeta": {
+          "filename": "../../modules/lambda/main.tf",
+          "line_end": 61,
+          "line_start": 55
+        },
+        "id": "403d05e8-25e2-442a-bff2-eac827181b7e",
+        "variables": {
+          "DYNAMODB_TABLE": "serverless-app-dev-data",
+          "ENVIRONMENT": "dev",
+          "S3_BUCKET": "serverless-app-dev-storage"
+        }
+      },
+      "filename": {
+        "__attribute__": "data.archive_file.lambda_code.output_path",
+        "__name__": "lambda_code",
+        "__ref__": "e67463d5-370f-4070-b6ac-3c7602da2544",
+        "__type__": "archive_file"
+      },
+      "function_name": "serverless-app-dev-function",
+      "handler": "index.handler",
+      "id": "a2e43157-2906-40d6-ac61-8c8f38893ba4",
+      "memory_size": 128,
+      "role": "307d8b4e-af59-4745-8a1b-969016359af3",
+      "runtime": "nodejs18.x",
+      "source_code_hash": {
+        "__attribute__": "data.archive_file.lambda_code.output_base64sha256",
+        "__name__": "lambda_code",
+        "__ref__": "e67463d5-370f-4070-b6ac-3c7602da2544",
+        "__type__": "archive_file"
+      },
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "timeout": 10,
+      "vpc_config": {
+        "__tfmeta": {
+          "filename": "../../modules/lambda/main.tf",
+          "line_end": 53,
+          "line_start": 50
+        },
+        "id": "faf75ffb-59cc-435a-87fb-386b2e741a52",
+        "security_group_ids": {
+          "__attributes__": [
+            "aws_security_group.lambda.id"
+          ],
+          "__name__": "lambda",
+          "__ref__": "13830419-ad30-4610-ac40-179ff05a0d1d",
+          "__type__": "aws_security_group"
+        },
+        "subnet_ids": [
+          "d28771c4-ad24-4b28-9819-1f2a8bec355e",
+          "c7bdd566-0f77-43ba-b654-12f50289559c"
+        ]
+      }
+    }
+  ],
+  "aws_lambda_permission": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/main.tf",
+        "label": "aws_lambda_permission",
+        "line_end": 74,
+        "line_start": 69,
+        "path": "module.lambda.aws_lambda_permission.api_gateway",
+        "type": "resource"
+      },
+      "action": "lambda:InvokeFunction",
+      "function_name": {
+        "__attribute__": "aws_lambda_function.this.function_name",
+        "__name__": "this",
+        "__ref__": "a2e43157-2906-40d6-ac61-8c8f38893ba4",
+        "__type__": "aws_lambda_function"
+      },
+      "id": "31f4f32c-64ff-48c6-9de2-7b0a0a93737f",
+      "principal": "apigateway.amazonaws.com",
+      "statement_id": "AllowAPIGatewayInvoke"
+    }
+  ],
+  "aws_nat_gateway": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_nat_gateway",
+        "line_end": 92,
+        "line_start": 79,
+        "path": "module.vpc.aws_nat_gateway.this[0]",
+        "type": "resource"
+      },
+      "allocation_id": {
+        "__attributes__": [
+          "aws_eip.nat",
+          "count.index"
+        ],
+        "__name__": "nat[0]",
+        "__ref__": "b1b9856a-37cf-4bf9-b985-7a1ea1c344eb",
+        "__type__": "aws_eip"
+      },
+      "count": 2,
+      "depends_on": {
+        "__attributes__": [
+          "aws_internet_gateway.this"
+        ],
+        "__name__": "this",
+        "__ref__": "c4fc88be-84bf-4e9d-85e1-5b3269e64d91",
+        "__type__": "aws_internet_gateway"
+      },
+      "id": "850aed41-48a6-4bac-9d4a-b7e4d45d282c",
+      "subnet_id": {
+        "__attributes__": [
+          "aws_subnet.public",
+          "count.index"
+        ],
+        "__name__": "public[0]",
+        "__ref__": "656c0f93-9133-4a2b-962c-8123e54371d8",
+        "__type__": "aws_subnet"
+      },
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-nat-gw-1",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_nat_gateway",
+        "line_end": 92,
+        "line_start": 79,
+        "path": "module.vpc.aws_nat_gateway.this[1]",
+        "type": "resource"
+      },
+      "allocation_id": {
+        "__attributes__": [
+          "aws_eip.nat",
+          "count.index"
+        ],
+        "__name__": "nat[1]",
+        "__ref__": "0c747ead-bad3-4b69-84ad-5fea56c08c8a",
+        "__type__": "aws_eip"
+      },
+      "count": 2,
+      "depends_on": {
+        "__attributes__": [
+          "aws_internet_gateway.this"
+        ],
+        "__name__": "this",
+        "__ref__": "c4fc88be-84bf-4e9d-85e1-5b3269e64d91",
+        "__type__": "aws_internet_gateway"
+      },
+      "id": "fed734dc-0379-4b18-a37a-d2dc2fc10426",
+      "subnet_id": {
+        "__attributes__": [
+          "aws_subnet.public",
+          "count.index"
+        ],
+        "__name__": "public[1]",
+        "__ref__": "cda46455-a2a7-4e13-a34f-84fbd87f8a63",
+        "__type__": "aws_subnet"
+      },
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-nat-gw-2",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    }
+  ],
+  "aws_region": [
+    {
+      "__tfmeta": {
+        "filename": "data.tf",
+        "label": "aws_region",
+        "line_end": 3,
+        "line_start": 3,
+        "path": "data.aws_region.current",
+        "type": "data"
+      },
+      "id": "948df308-ce14-4841-820c-7d99597ad230"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/waf/main.tf",
+        "label": "aws_region",
+        "line_end": 102,
+        "line_start": 102,
+        "path": "module.waf.data.aws_region.current",
+        "type": "data"
+      },
+      "id": "639692cc-0b0f-41aa-8536-aaf20bd2b2da"
+    }
+  ],
+  "aws_route_table": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_route_table",
+        "line_end": 111,
+        "line_start": 97,
+        "path": "module.vpc.aws_route_table.public",
+        "type": "resource"
+      },
+      "id": "aa013dfc-914b-481a-918b-178e60db5268",
+      "route": {
+        "__tfmeta": {
+          "filename": "../../modules/vpc/main.tf",
+          "line_end": 103,
+          "line_start": 100
+        },
+        "cidr_block": "0.0.0.0/0",
+        "gateway_id": {
+          "__attribute__": "aws_internet_gateway.this.id",
+          "__name__": "this",
+          "__ref__": "c4fc88be-84bf-4e9d-85e1-5b3269e64d91",
+          "__type__": "aws_internet_gateway"
+        },
+        "id": "26e9858a-d10a-4604-8499-9a29c0143e77"
+      },
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-public-rt",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "vpc_id": {
+        "__attribute__": "aws_vpc.this.id",
+        "__name__": "this",
+        "__ref__": "412261b3-d02a-4504-9127-abe62236d13e",
+        "__type__": "aws_vpc"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_route_table",
+        "line_end": 128,
+        "line_start": 113,
+        "path": "module.vpc.aws_route_table.private[0]",
+        "type": "resource"
+      },
+      "count": 2,
+      "id": "439b2426-497d-4b30-a992-c51145a71855",
+      "route": {
+        "__tfmeta": {
+          "filename": "../../modules/vpc/main.tf",
+          "line_end": 120,
+          "line_start": 117
+        },
+        "cidr_block": "0.0.0.0/0",
+        "id": "306ede87-b0c7-4ee3-a12b-379ef0cc8773",
+        "nat_gateway_id": {
+          "__attributes__": [
+            "aws_nat_gateway.this",
+            "count.index"
+          ],
+          "__name__": "this[0]",
+          "__ref__": "850aed41-48a6-4bac-9d4a-b7e4d45d282c",
+          "__type__": "aws_nat_gateway"
+        }
+      },
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-private-rt-1",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "vpc_id": {
+        "__attribute__": "aws_vpc.this.id",
+        "__name__": "this",
+        "__ref__": "412261b3-d02a-4504-9127-abe62236d13e",
+        "__type__": "aws_vpc"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_route_table",
+        "line_end": 128,
+        "line_start": 113,
+        "path": "module.vpc.aws_route_table.private[1]",
+        "type": "resource"
+      },
+      "count": 2,
+      "id": "20636545-7c73-4972-8168-70a6144912dc",
+      "route": {
+        "__tfmeta": {
+          "filename": "../../modules/vpc/main.tf",
+          "line_end": 120,
+          "line_start": 117
+        },
+        "cidr_block": "0.0.0.0/0",
+        "id": "238c3cc7-9933-4541-907d-caee2cfc5be3",
+        "nat_gateway_id": {
+          "__attributes__": [
+            "aws_nat_gateway.this",
+            "count.index"
+          ],
+          "__name__": "this[1]",
+          "__ref__": "fed734dc-0379-4b18-a37a-d2dc2fc10426",
+          "__type__": "aws_nat_gateway"
+        }
+      },
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-private-rt-2",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "vpc_id": {
+        "__attribute__": "aws_vpc.this.id",
+        "__name__": "this",
+        "__ref__": "412261b3-d02a-4504-9127-abe62236d13e",
+        "__type__": "aws_vpc"
+      }
+    }
+  ],
+  "aws_route_table_association": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_route_table_association",
+        "line_end": 140,
+        "line_start": 136,
+        "path": "module.vpc.aws_route_table_association.private[0]",
+        "type": "resource"
+      },
+      "count": 2,
+      "id": "2570061a-569e-49df-9148-b3a7b9cc3558",
+      "route_table_id": {
+        "__attributes__": [
+          "aws_route_table.private",
+          "count.index"
+        ],
+        "__name__": "private[0]",
+        "__ref__": "439b2426-497d-4b30-a992-c51145a71855",
+        "__type__": "aws_route_table"
+      },
+      "subnet_id": {
+        "__attributes__": [
+          "aws_subnet.private",
+          "count.index"
+        ],
+        "__name__": "private[0]",
+        "__ref__": "d28771c4-ad24-4b28-9819-1f2a8bec355e",
+        "__type__": "aws_subnet"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_route_table_association",
+        "line_end": 140,
+        "line_start": 136,
+        "path": "module.vpc.aws_route_table_association.private[1]",
+        "type": "resource"
+      },
+      "count": 2,
+      "id": "53df68ef-dbe4-43ad-aeb5-299fd453bb7a",
+      "route_table_id": {
+        "__attributes__": [
+          "aws_route_table.private",
+          "count.index"
+        ],
+        "__name__": "private[1]",
+        "__ref__": "20636545-7c73-4972-8168-70a6144912dc",
+        "__type__": "aws_route_table"
+      },
+      "subnet_id": {
+        "__attributes__": [
+          "aws_subnet.private",
+          "count.index"
+        ],
+        "__name__": "private[1]",
+        "__ref__": "c7bdd566-0f77-43ba-b654-12f50289559c",
+        "__type__": "aws_subnet"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_route_table_association",
+        "line_end": 134,
+        "line_start": 130,
+        "path": "module.vpc.aws_route_table_association.public[0]",
+        "type": "resource"
+      },
+      "count": 2,
+      "id": "507f410b-0c3a-49d6-a696-8d8dcc4c16b2",
+      "route_table_id": {
+        "__attribute__": "aws_route_table.public.id",
+        "__name__": "public",
+        "__ref__": "aa013dfc-914b-481a-918b-178e60db5268",
+        "__type__": "aws_route_table"
+      },
+      "subnet_id": {
+        "__attributes__": [
+          "aws_subnet.public",
+          "count.index"
+        ],
+        "__name__": "public[0]",
+        "__ref__": "656c0f93-9133-4a2b-962c-8123e54371d8",
+        "__type__": "aws_subnet"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_route_table_association",
+        "line_end": 134,
+        "line_start": 130,
+        "path": "module.vpc.aws_route_table_association.public[1]",
+        "type": "resource"
+      },
+      "count": 2,
+      "id": "d0e94ae4-f37b-4c4b-b116-95ea30b49edc",
+      "route_table_id": {
+        "__attribute__": "aws_route_table.public.id",
+        "__name__": "public",
+        "__ref__": "aa013dfc-914b-481a-918b-178e60db5268",
+        "__type__": "aws_route_table"
+      },
+      "subnet_id": {
+        "__attributes__": [
+          "aws_subnet.public",
+          "count.index"
+        ],
+        "__name__": "public[1]",
+        "__ref__": "cda46455-a2a7-4e13-a34f-84fbd87f8a63",
+        "__type__": "aws_subnet"
+      }
+    }
+  ],
+  "aws_s3_bucket": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/s3/main.tf",
+        "label": "aws_s3_bucket",
+        "line_end": 9,
+        "line_start": 4,
+        "path": "module.s3.aws_s3_bucket.this",
+        "type": "resource"
+      },
+      "bucket": "serverless-app-dev-storage",
+      "force_destroy": true,
+      "id": "39c89a96-fc65-4b87-918a-12cb6fe1265e",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    }
+  ],
+  "aws_s3_bucket_public_access_block": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/s3/main.tf",
+        "label": "aws_s3_bucket_public_access_block",
+        "line_end": 45,
+        "line_start": 38,
+        "path": "module.s3.aws_s3_bucket_public_access_block.this",
+        "type": "resource"
+      },
+      "block_public_acls": true,
+      "block_public_policy": true,
+      "bucket": {
+        "__attribute__": "aws_s3_bucket.this.id",
+        "__name__": "this",
+        "__ref__": "39c89a96-fc65-4b87-918a-12cb6fe1265e",
+        "__type__": "aws_s3_bucket"
+      },
+      "id": "48a6b9ec-f506-4354-95b7-7417528d8cf3",
+      "ignore_public_acls": true,
+      "restrict_public_buckets": true
+    }
+  ],
+  "aws_s3_bucket_server_side_encryption_configuration": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/s3/main.tf",
+        "label": "aws_s3_bucket_server_side_encryption_configuration",
+        "line_end": 22,
+        "line_start": 14,
+        "path": "module.s3.aws_s3_bucket_server_side_encryption_configuration.this",
+        "type": "resource"
+      },
+      "bucket": {
+        "__attribute__": "aws_s3_bucket.this.id",
+        "__name__": "this",
+        "__ref__": "39c89a96-fc65-4b87-918a-12cb6fe1265e",
+        "__type__": "aws_s3_bucket"
+      },
+      "id": "84cf4251-0997-4ea1-a8c1-b8331a4ccb7b",
+      "rule": {
+        "__tfmeta": {
+          "filename": "../../modules/s3/main.tf",
+          "line_end": 21,
+          "line_start": 17
+        },
+        "apply_server_side_encryption_by_default": {
+          "__tfmeta": {
+            "filename": "../../modules/s3/main.tf",
+            "line_end": 20,
+            "line_start": 18
+          },
+          "id": "01f58fcb-4540-47fe-9a55-9ae37e79e533",
+          "sse_algorithm": "AES256"
+        },
+        "id": "69a4627e-85a3-4095-9ddc-4217f2ecd165"
+      }
+    }
+  ],
+  "aws_s3_bucket_versioning": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/s3/main.tf",
+        "label": "aws_s3_bucket_versioning",
+        "line_end": 33,
+        "line_start": 27,
+        "path": "module.s3.aws_s3_bucket_versioning.this",
+        "type": "resource"
+      },
+      "bucket": {
+        "__attribute__": "aws_s3_bucket.this.id",
+        "__name__": "this",
+        "__ref__": "39c89a96-fc65-4b87-918a-12cb6fe1265e",
+        "__type__": "aws_s3_bucket"
+      },
+      "id": "b71d9fc8-591a-413f-8919-de5787dabc96",
+      "versioning_configuration": {
+        "__tfmeta": {
+          "filename": "../../modules/s3/main.tf",
+          "line_end": 32,
+          "line_start": 30
+        },
+        "id": "04081ccf-64d5-4dff-a27d-ff0662da7b4e",
+        "status": "Enabled"
+      }
+    }
+  ],
+  "aws_security_group": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/main.tf",
+        "label": "aws_security_group",
+        "line_end": 97,
+        "line_start": 79,
+        "path": "module.lambda.aws_security_group.lambda",
+        "type": "resource"
+      },
+      "description": "Security group for Lambda functions",
+      "egress": {
+        "__tfmeta": {
+          "filename": "../../modules/lambda/main.tf",
+          "line_end": 89,
+          "line_start": 84
+        },
+        "cidr_blocks": [
+          "0.0.0.0/0"
+        ],
+        "from_port": 0,
+        "id": "75b1c673-34e5-47f6-a122-8dad62fa0287",
+        "protocol": "-1",
+        "to_port": 0
+      },
+      "id": "13830419-ad30-4610-ac40-179ff05a0d1d",
+      "name": "serverless-app-dev-lambda-sg",
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-lambda-sg",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "vpc_id": "412261b3-d02a-4504-9127-abe62236d13e"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_security_group",
+        "line_end": 163,
+        "line_start": 145,
+        "path": "module.vpc.aws_security_group.lambda",
+        "type": "resource"
+      },
+      "description": "Security group for Lambda functions",
+      "egress": {
+        "__tfmeta": {
+          "filename": "../../modules/vpc/main.tf",
+          "line_end": 155,
+          "line_start": 150
+        },
+        "cidr_blocks": [
+          "0.0.0.0/0"
+        ],
+        "from_port": 0,
+        "id": "63a0b03a-6738-4545-a626-5cfc8434eb25",
+        "protocol": "-1",
+        "to_port": 0
+      },
+      "id": "c0dfcab2-f26c-4d90-9d2a-c3b2a197e459",
+      "name": "serverless-app-dev-lambda-sg",
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-lambda-sg",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "vpc_id": {
+        "__attribute__": "aws_vpc.this.id",
+        "__name__": "this",
+        "__ref__": "412261b3-d02a-4504-9127-abe62236d13e",
+        "__type__": "aws_vpc"
+      }
+    }
+  ],
+  "aws_subnet": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_subnet",
+        "line_end": 47,
+        "line_start": 35,
+        "path": "module.vpc.aws_subnet.private[0]",
+        "type": "resource"
+      },
+      "availability_zone": null,
+      "cidr_block": "10.0.11.0/24",
+      "count": 2,
+      "id": "d28771c4-ad24-4b28-9819-1f2a8bec355e",
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-private-subnet-1",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "vpc_id": {
+        "__attribute__": "aws_vpc.this.id",
+        "__name__": "this",
+        "__ref__": "412261b3-d02a-4504-9127-abe62236d13e",
+        "__type__": "aws_vpc"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_subnet",
+        "line_end": 47,
+        "line_start": 35,
+        "path": "module.vpc.aws_subnet.private[1]",
+        "type": "resource"
+      },
+      "availability_zone": null,
+      "cidr_block": "10.0.12.0/24",
+      "count": 2,
+      "id": "c7bdd566-0f77-43ba-b654-12f50289559c",
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-private-subnet-2",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "vpc_id": {
+        "__attribute__": "aws_vpc.this.id",
+        "__name__": "this",
+        "__ref__": "412261b3-d02a-4504-9127-abe62236d13e",
+        "__type__": "aws_vpc"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_subnet",
+        "line_end": 33,
+        "line_start": 20,
+        "path": "module.vpc.aws_subnet.public[0]",
+        "type": "resource"
+      },
+      "availability_zone": null,
+      "cidr_block": "10.0.1.0/24",
+      "count": 2,
+      "id": "656c0f93-9133-4a2b-962c-8123e54371d8",
+      "map_public_ip_on_launch": true,
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-public-subnet-1",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "vpc_id": {
+        "__attribute__": "aws_vpc.this.id",
+        "__name__": "this",
+        "__ref__": "412261b3-d02a-4504-9127-abe62236d13e",
+        "__type__": "aws_vpc"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_subnet",
+        "line_end": 33,
+        "line_start": 20,
+        "path": "module.vpc.aws_subnet.public[1]",
+        "type": "resource"
+      },
+      "availability_zone": null,
+      "cidr_block": "10.0.2.0/24",
+      "count": 2,
+      "id": "cda46455-a2a7-4e13-a34f-84fbd87f8a63",
+      "map_public_ip_on_launch": true,
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-public-subnet-2",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "vpc_id": {
+        "__attribute__": "aws_vpc.this.id",
+        "__name__": "this",
+        "__ref__": "412261b3-d02a-4504-9127-abe62236d13e",
+        "__type__": "aws_vpc"
+      }
+    }
+  ],
+  "aws_vpc": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/main.tf",
+        "label": "aws_vpc",
+        "line_end": 15,
+        "line_start": 4,
+        "path": "module.vpc.aws_vpc.this",
+        "type": "resource"
+      },
+      "cidr_block": "10.0.0.0/16",
+      "enable_dns_hostnames": true,
+      "enable_dns_support": true,
+      "id": "412261b3-d02a-4504-9127-abe62236d13e",
+      "tags": {
+        "Environment": "Development",
+        "Name": "serverless-app-dev-vpc",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    }
+  ],
+  "aws_wafv2_web_acl": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/waf/main.tf",
+        "label": "aws_wafv2_web_acl",
+        "line_end": 89,
+        "line_start": 4,
+        "path": "module.waf.aws_wafv2_web_acl.this",
+        "type": "resource"
+      },
+      "default_action": {
+        "__tfmeta": {
+          "filename": "../../modules/waf/main.tf",
+          "line_end": 11,
+          "line_start": 9
+        },
+        "allow": {
+          "__tfmeta": {
+            "filename": "../../modules/waf/main.tf",
+            "line_end": 10,
+            "line_start": 10
+          },
+          "id": "17417d33-1bb6-4dbe-b3e3-fd60ab9cd765"
+        },
+        "id": "c14aedb3-1d08-4baf-9be4-47285d9806ae"
+      },
+      "description": "WAF Web ACL for serverless-app dev",
+      "id": "474e2e51-023b-4ad7-844b-96ec86768402",
+      "name": "serverless-app-dev-web-acl",
+      "rule": [
+        {
+          "__tfmeta": {
+            "filename": "../../modules/waf/main.tf",
+            "line_end": 34,
+            "line_start": 14
+          },
+          "id": "a8b8232c-ff8d-44c0-95ef-721886b71a66",
+          "name": "AWS-AWSManagedRulesCommonRuleSet",
+          "override_action": {
+            "__tfmeta": {
+              "filename": "../../modules/waf/main.tf",
+              "line_end": 20,
+              "line_start": 18
+            },
+            "id": "7ffa0c2d-8549-4bc1-832a-418159996236",
+            "none": {
+              "__tfmeta": {
+                "filename": "../../modules/waf/main.tf",
+                "line_end": 19,
+                "line_start": 19
+              },
+              "id": "f30bbd1a-f166-42cd-a735-8af1aaa02fda"
+            }
+          },
+          "priority": 1,
+          "statement": {
+            "__tfmeta": {
+              "filename": "../../modules/waf/main.tf",
+              "line_end": 27,
+              "line_start": 22
+            },
+            "id": "b5719770-af20-4eeb-9bdc-eb2615776070",
+            "managed_rule_group_statement": {
+              "__tfmeta": {
+                "filename": "../../modules/waf/main.tf",
+                "line_end": 26,
+                "line_start": 23
+              },
+              "id": "d114c728-d75e-4195-9961-f9d0642902e4",
+              "name": "AWSManagedRulesCommonRuleSet",
+              "vendor_name": "AWS"
+            }
+          },
+          "visibility_config": {
+            "__tfmeta": {
+              "filename": "../../modules/waf/main.tf",
+              "line_end": 33,
+              "line_start": 29
+            },
+            "cloudwatch_metrics_enabled": true,
+            "id": "549509c3-e6e3-4632-bd5a-fdc663ee0ce5",
+            "metric_name": "AWS-AWSManagedRulesCommonRuleSet",
+            "sampled_requests_enabled": true
+          }
+        },
+        {
+          "__tfmeta": {
+            "filename": "../../modules/waf/main.tf",
+            "line_end": 57,
+            "line_start": 37
+          },
+          "id": "e91e5f1a-60d2-4ac1-97f7-de318a598ecd",
+          "name": "AWS-AWSManagedRulesKnownBadInputsRuleSet",
+          "override_action": {
+            "__tfmeta": {
+              "filename": "../../modules/waf/main.tf",
+              "line_end": 43,
+              "line_start": 41
+            },
+            "id": "0f8b73de-52b8-4229-993e-14d5e4f8483d",
+            "none": {
+              "__tfmeta": {
+                "filename": "../../modules/waf/main.tf",
+                "line_end": 42,
+                "line_start": 42
+              },
+              "id": "e8511dbd-0c46-437e-a560-c6699f508f2a"
+            }
+          },
+          "priority": 2,
+          "statement": {
+            "__tfmeta": {
+              "filename": "../../modules/waf/main.tf",
+              "line_end": 50,
+              "line_start": 45
+            },
+            "id": "d4886c34-58af-4fbe-997e-17c746e1bcd3",
+            "managed_rule_group_statement": {
+              "__tfmeta": {
+                "filename": "../../modules/waf/main.tf",
+                "line_end": 49,
+                "line_start": 46
+              },
+              "id": "43e41fd9-ae96-433b-979f-68e9e128b609",
+              "name": "AWSManagedRulesKnownBadInputsRuleSet",
+              "vendor_name": "AWS"
+            }
+          },
+          "visibility_config": {
+            "__tfmeta": {
+              "filename": "../../modules/waf/main.tf",
+              "line_end": 56,
+              "line_start": 52
+            },
+            "cloudwatch_metrics_enabled": true,
+            "id": "378dcdd0-235d-4ebd-8c38-5fb648158efc",
+            "metric_name": "AWS-AWSManagedRulesKnownBadInputsRuleSet",
+            "sampled_requests_enabled": true
+          }
+        },
+        {
+          "__tfmeta": {
+            "filename": "../../modules/waf/main.tf",
+            "line_end": 80,
+            "line_start": 60
+          },
+          "action": {
+            "__tfmeta": {
+              "filename": "../../modules/waf/main.tf",
+              "line_end": 66,
+              "line_start": 64
+            },
+            "block": {
+              "__tfmeta": {
+                "filename": "../../modules/waf/main.tf",
+                "line_end": 65,
+                "line_start": 65
+              },
+              "id": "c0d6f923-30eb-4574-9d24-09f5501cc52f"
+            },
+            "id": "a25d1e12-f6a9-4d32-9edb-83fe53192086"
+          },
+          "id": "ebf6b937-989c-4f20-a745-a31046886b29",
+          "name": "RateBasedRule",
+          "priority": 3,
+          "statement": {
+            "__tfmeta": {
+              "filename": "../../modules/waf/main.tf",
+              "line_end": 73,
+              "line_start": 68
+            },
+            "id": "aa89e816-4fff-44d0-b491-d8387fa29178",
+            "rate_based_statement": {
+              "__tfmeta": {
+                "filename": "../../modules/waf/main.tf",
+                "line_end": 72,
+                "line_start": 69
+              },
+              "aggregate_key_type": "IP",
+              "id": "cfbcf41c-d59a-4627-bee0-547be5940d4a",
+              "limit": 1000
+            }
+          },
+          "visibility_config": {
+            "__tfmeta": {
+              "filename": "../../modules/waf/main.tf",
+              "line_end": 79,
+              "line_start": 75
+            },
+            "cloudwatch_metrics_enabled": true,
+            "id": "079b75cc-3892-49f7-9a29-12f3d368f5cf",
+            "metric_name": "RateBasedRule",
+            "sampled_requests_enabled": true
+          }
+        }
+      ],
+      "scope": "REGIONAL",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "visibility_config": {
+        "__tfmeta": {
+          "filename": "../../modules/waf/main.tf",
+          "line_end": 86,
+          "line_start": 82
+        },
+        "cloudwatch_metrics_enabled": true,
+        "id": "e4108e22-84a0-4610-8b71-c219acebda2c",
+        "metric_name": "serverless-app-dev-web-acl",
+        "sampled_requests_enabled": true
+      }
+    }
+  ],
+  "aws_wafv2_web_acl_association": [
+    {
+      "__tfmeta": {
+        "filename": "../../modules/waf/main.tf",
+        "label": "aws_wafv2_web_acl_association",
+        "line_end": 97,
+        "line_start": 94,
+        "path": "module.waf.aws_wafv2_web_acl_association.this",
+        "type": "resource"
+      },
+      "id": "ae180b78-13bb-4783-9baa-8e4eb5e0da74",
+      "resource_arn": {
+        "__attributes__": [
+          "data.aws_region.current.name",
+          "var.api_gateway_id",
+          "var.stage_name"
+        ],
+        "__name__": "current",
+        "__ref__": "639692cc-0b0f-41aa-8536-aaf20bd2b2da",
+        "__type__": "aws_region"
+      },
+      "web_acl_arn": {
+        "__attribute__": "aws_wafv2_web_acl.this.arn",
+        "__name__": "this",
+        "__ref__": "474e2e51-023b-4ad7-844b-96ec86768402",
+        "__type__": "aws_wafv2_web_acl"
+      }
+    }
+  ],
+  "locals": [
+    {
+      "__tfmeta": {
+        "filename": "locals.tf",
+        "line_end": 29,
+        "line_start": 1,
+        "path": "locals"
+      },
+      "environment": "dev",
+      "force_destroy": true,
+      "id": "9c3f5e3b-a544-4be5-9870-8cf4ff49cc03",
+      "lambda_runtime": "nodejs18.x",
+      "memory_size": 128,
+      "private_subnet_cidrs": [
+        "10.0.11.0/24",
+        "10.0.12.0/24"
+      ],
+      "project": "serverless-app",
+      "public_subnet_cidrs": [
+        "10.0.1.0/24",
+        "10.0.2.0/24"
+      ],
+      "read_capacity": 5,
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "timeout": 10,
+      "vpc_cidr": "10.0.0.0/16",
+      "write_capacity": 5
+    }
+  ],
+  "module": [
+    {
+      "__tfmeta": {
+        "filename": "main.tf",
+        "label": "api_gateway",
+        "line_end": 70,
+        "line_start": 62,
+        "path": "module.api_gateway"
+      },
+      "environment": "dev",
+      "id": "79e187a2-7fe4-4a6d-8e2d-795c0571120d",
+      "lambda_function_name": "serverless-app-dev-function",
+      "lambda_invoke_arn": null,
+      "project": "serverless-app",
+      "source": "../../modules/api_gateway",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "main.tf",
+        "label": "dynamodb",
+        "line_end": 41,
+        "line_start": 33,
+        "path": "module.dynamodb"
+      },
+      "environment": "dev",
+      "id": "9885f5e7-d296-41d8-a0b4-463a899c0781",
+      "project": "serverless-app",
+      "read_capacity": 5,
+      "source": "../../modules/dynamodb",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "write_capacity": 5
+    },
+    {
+      "__tfmeta": {
+        "filename": "main.tf",
+        "label": "iam",
+        "line_end": 20,
+        "line_start": 14,
+        "path": "module.iam"
+      },
+      "environment": "dev",
+      "id": "e7c6145a-b78b-42b1-8406-6557920042c1",
+      "project": "serverless-app",
+      "source": "../../modules/iam",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "main.tf",
+        "label": "lambda",
+        "line_end": 59,
+        "line_start": 44,
+        "path": "module.lambda"
+      },
+      "dynamodb_table_arn": "4915aa85-409d-4771-b1c2-dde27e1deb1d",
+      "dynamodb_table_name": "serverless-app-dev-data",
+      "environment": "dev",
+      "id": "ca709843-62ff-4989-9f66-ffd418721a35",
+      "lambda_role_arn": "307d8b4e-af59-4745-8a1b-969016359af3",
+      "lambda_runtime": "nodejs18.x",
+      "memory_size": 128,
+      "project": "serverless-app",
+      "s3_bucket_name": "serverless-app-dev-storage",
+      "source": "../../modules/lambda",
+      "subnet_ids": [
+        "d28771c4-ad24-4b28-9819-1f2a8bec355e",
+        "c7bdd566-0f77-43ba-b654-12f50289559c"
+      ],
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "timeout": 10,
+      "vpc_id": "412261b3-d02a-4504-9127-abe62236d13e"
+    },
+    {
+      "__tfmeta": {
+        "filename": "main.tf",
+        "label": "s3",
+        "line_end": 30,
+        "line_start": 23,
+        "path": "module.s3"
+      },
+      "environment": "dev",
+      "force_destroy": true,
+      "id": "cd62e651-248a-4d5c-a922-653db778fc69",
+      "project": "serverless-app",
+      "source": "../../modules/s3",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "main.tf",
+        "label": "vpc",
+        "line_end": 11,
+        "line_start": 2,
+        "path": "module.vpc"
+      },
+      "environment": "dev",
+      "id": "dd355502-6759-46ce-8ec6-434e2a8477a2",
+      "private_subnet_cidrs": [
+        "10.0.11.0/24",
+        "10.0.12.0/24"
+      ],
+      "project": "serverless-app",
+      "public_subnet_cidrs": [
+        "10.0.1.0/24",
+        "10.0.2.0/24"
+      ],
+      "source": "../../modules/vpc",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      },
+      "vpc_cidr": "10.0.0.0/16"
+    },
+    {
+      "__tfmeta": {
+        "filename": "main.tf",
+        "label": "waf",
+        "line_end": 81,
+        "line_start": 73,
+        "path": "module.waf"
+      },
+      "api_gateway_id": "1c193eca-1be1-49b4-b42c-ab26d6f64710",
+      "environment": "dev",
+      "id": "fcdaf513-2a14-4bd5-9e0e-8517249df90b",
+      "project": "serverless-app",
+      "source": "../../modules/waf",
+      "stage_name": "dev",
+      "tags": {
+        "Environment": "Development",
+        "Owner": "DevTeam",
+        "Project": "ServerlessApp",
+        "Terraform": "true"
+      }
+    }
+  ],
+  "output": [
+    {
+      "__tfmeta": {
+        "filename": "outputs.tf",
+        "label": "api_gateway_stage",
+        "line_end": 29,
+        "line_start": 26,
+        "path": "output.api_gateway_stage"
+      },
+      "description": "API Gateway stage name",
+      "id": "a808e037-c899-42b9-99b3-8307003bb1c7",
+      "value": "dev"
+    },
+    {
+      "__tfmeta": {
+        "filename": "outputs.tf",
+        "label": "api_gateway_url",
+        "line_end": 24,
+        "line_start": 21,
+        "path": "output.api_gateway_url"
+      },
+      "description": "API Gateway invoke URL",
+      "id": "efc37af3-68a8-40ff-8bef-e09a7235f929",
+      "value": null
+    },
+    {
+      "__tfmeta": {
+        "filename": "outputs.tf",
+        "label": "dynamodb_table_name",
+        "line_end": 14,
+        "line_start": 11,
+        "path": "output.dynamodb_table_name"
+      },
+      "description": "DynamoDB table name",
+      "id": "5bb1f1f3-3cce-4ba1-9e18-766940bed686",
+      "value": "serverless-app-dev-data"
+    },
+    {
+      "__tfmeta": {
+        "filename": "outputs.tf",
+        "label": "lambda_function_name",
+        "line_end": 19,
+        "line_start": 16,
+        "path": "output.lambda_function_name"
+      },
+      "description": "Lambda function name",
+      "id": "c784c7b8-1054-4582-be77-c986ac9c85b8",
+      "value": "serverless-app-dev-function"
+    },
+    {
+      "__tfmeta": {
+        "filename": "outputs.tf",
+        "label": "s3_bucket_name",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "output.s3_bucket_name"
+      },
+      "description": "S3 bucket name",
+      "id": "7c71bf79-d1d8-4522-8878-32b93d5eb3ee",
+      "value": "serverless-app-dev-storage"
+    },
+    {
+      "__tfmeta": {
+        "filename": "outputs.tf",
+        "label": "vpc_id",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "output.vpc_id"
+      },
+      "description": "VPC ID",
+      "id": "1a61b78e-1507-4307-864c-c670ce28114a",
+      "value": "412261b3-d02a-4504-9127-abe62236d13e"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/outputs.tf",
+        "label": "api_id",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.api_gateway.output.api_id"
+      },
+      "description": "ID of the API Gateway REST API",
+      "id": "07559b19-fe52-4767-b640-133492326007",
+      "value": {
+        "__attribute__": "aws_api_gateway_rest_api.this.id",
+        "__name__": "this",
+        "__ref__": "1c193eca-1be1-49b4-b42c-ab26d6f64710",
+        "__type__": "aws_api_gateway_rest_api"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/outputs.tf",
+        "label": "execution_arn",
+        "line_end": 19,
+        "line_start": 16,
+        "path": "module.api_gateway.output.execution_arn"
+      },
+      "description": "Execution ARN of the API Gateway",
+      "id": "1e0c0c42-99eb-4050-9a06-f3dd2fbbb61b",
+      "value": {
+        "__attribute__": "aws_api_gateway_rest_api.this.execution_arn",
+        "__name__": "this",
+        "__ref__": "1c193eca-1be1-49b4-b42c-ab26d6f64710",
+        "__type__": "aws_api_gateway_rest_api"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/outputs.tf",
+        "label": "invoke_url",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.api_gateway.output.invoke_url"
+      },
+      "description": "Invoke URL of the API Gateway",
+      "id": "dbaaeb04-c43e-406e-97d9-6bb59a0a4822",
+      "value": {
+        "__attributes__": [
+          "aws_api_gateway_deployment.this.invoke_url",
+          "aws_api_gateway_resource.this.path"
+        ],
+        "__name__": "this",
+        "__ref__": "9f43f402-763c-4c53-8d59-576435dbf486",
+        "__type__": "aws_api_gateway_deployment"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/outputs.tf",
+        "label": "stage_name",
+        "line_end": 14,
+        "line_start": 11,
+        "path": "module.api_gateway.output.stage_name"
+      },
+      "description": "Stage name of the API Gateway",
+      "id": "4f48ce60-907b-4134-a8f6-46e2f630f654",
+      "value": {
+        "__attribute__": "aws_api_gateway_stage.this.stage_name",
+        "__name__": "this",
+        "__ref__": "30b559df-cdf8-49cf-b6c5-af082436771c",
+        "__type__": "aws_api_gateway_stage"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/dynamodb/outputs.tf",
+        "label": "table_arn",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.dynamodb.output.table_arn"
+      },
+      "description": "ARN of the DynamoDB table",
+      "id": "37d4494f-dbee-487f-a6e5-91e9af1a8a4e",
+      "value": {
+        "__attribute__": "aws_dynamodb_table.this.arn",
+        "__name__": "this",
+        "__ref__": "4915aa85-409d-4771-b1c2-dde27e1deb1d",
+        "__type__": "aws_dynamodb_table"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/dynamodb/outputs.tf",
+        "label": "table_id",
+        "line_end": 14,
+        "line_start": 11,
+        "path": "module.dynamodb.output.table_id"
+      },
+      "description": "ID of the DynamoDB table",
+      "id": "eb507a28-59bb-41aa-b7d4-5ad80109f1af",
+      "value": {
+        "__attribute__": "aws_dynamodb_table.this.id",
+        "__name__": "this",
+        "__ref__": "4915aa85-409d-4771-b1c2-dde27e1deb1d",
+        "__type__": "aws_dynamodb_table"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/dynamodb/outputs.tf",
+        "label": "table_name",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.dynamodb.output.table_name"
+      },
+      "description": "Name of the DynamoDB table",
+      "id": "01eb978f-3fa8-49f4-b400-80e8f4b363e2",
+      "value": {
+        "__attribute__": "aws_dynamodb_table.this.name",
+        "__name__": "this",
+        "__ref__": "4915aa85-409d-4771-b1c2-dde27e1deb1d",
+        "__type__": "aws_dynamodb_table"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/iam/outputs.tf",
+        "label": "lambda_role_arn",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.iam.output.lambda_role_arn"
+      },
+      "description": "ARN of the Lambda IAM role",
+      "id": "7fb73afa-f677-4de2-825d-3a9b93b1e422",
+      "value": {
+        "__attribute__": "aws_iam_role.lambda.arn",
+        "__name__": "lambda",
+        "__ref__": "307d8b4e-af59-4745-8a1b-969016359af3",
+        "__type__": "aws_iam_role"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/iam/outputs.tf",
+        "label": "lambda_role_name",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.iam.output.lambda_role_name"
+      },
+      "description": "Name of the Lambda IAM role",
+      "id": "50bf7af4-39b0-4557-96d4-f3f51afe1ade",
+      "value": {
+        "__attribute__": "aws_iam_role.lambda.name",
+        "__name__": "lambda",
+        "__ref__": "307d8b4e-af59-4745-8a1b-969016359af3",
+        "__type__": "aws_iam_role"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/outputs.tf",
+        "label": "function_arn",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.lambda.output.function_arn"
+      },
+      "description": "ARN of the Lambda function",
+      "id": "4a49669c-d7bc-4ed5-9a64-ed67447bbda4",
+      "value": {
+        "__attribute__": "aws_lambda_function.this.arn",
+        "__name__": "this",
+        "__ref__": "a2e43157-2906-40d6-ac61-8c8f38893ba4",
+        "__type__": "aws_lambda_function"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/outputs.tf",
+        "label": "function_name",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.lambda.output.function_name"
+      },
+      "description": "Name of the Lambda function",
+      "id": "64f0f213-9727-4e30-9df3-82628c4af7f7",
+      "value": {
+        "__attribute__": "aws_lambda_function.this.function_name",
+        "__name__": "this",
+        "__ref__": "a2e43157-2906-40d6-ac61-8c8f38893ba4",
+        "__type__": "aws_lambda_function"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/outputs.tf",
+        "label": "invoke_arn",
+        "line_end": 14,
+        "line_start": 11,
+        "path": "module.lambda.output.invoke_arn"
+      },
+      "description": "Invoke ARN of the Lambda function",
+      "id": "31ed5f59-13e0-469e-b7df-ecedfacee382",
+      "value": {
+        "__attribute__": "aws_lambda_function.this.invoke_arn",
+        "__name__": "this",
+        "__ref__": "a2e43157-2906-40d6-ac61-8c8f38893ba4",
+        "__type__": "aws_lambda_function"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/outputs.tf",
+        "label": "security_group_id",
+        "line_end": 19,
+        "line_start": 16,
+        "path": "module.lambda.output.security_group_id"
+      },
+      "description": "ID of the Lambda security group",
+      "id": "fe2c8abd-f7b1-49fd-930b-282d24af2db3",
+      "value": {
+        "__attribute__": "aws_security_group.lambda.id",
+        "__name__": "lambda",
+        "__ref__": "13830419-ad30-4610-ac40-179ff05a0d1d",
+        "__type__": "aws_security_group"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/s3/outputs.tf",
+        "label": "bucket_arn",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.s3.output.bucket_arn"
+      },
+      "description": "ARN of the S3 bucket",
+      "id": "ae6d6d9e-2341-4bbd-aa69-cb29f55dc048",
+      "value": {
+        "__attribute__": "aws_s3_bucket.this.arn",
+        "__name__": "this",
+        "__ref__": "39c89a96-fc65-4b87-918a-12cb6fe1265e",
+        "__type__": "aws_s3_bucket"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/s3/outputs.tf",
+        "label": "bucket_domain_name",
+        "line_end": 14,
+        "line_start": 11,
+        "path": "module.s3.output.bucket_domain_name"
+      },
+      "description": "Domain name of the S3 bucket",
+      "id": "fe139c99-8405-4e6b-b2c2-d1b86e08e9f5",
+      "value": {
+        "__attribute__": "aws_s3_bucket.this.bucket_domain_name",
+        "__name__": "this",
+        "__ref__": "39c89a96-fc65-4b87-918a-12cb6fe1265e",
+        "__type__": "aws_s3_bucket"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/s3/outputs.tf",
+        "label": "bucket_name",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.s3.output.bucket_name"
+      },
+      "description": "Name of the S3 bucket",
+      "id": "6584242c-3d86-4606-8469-143a21cdcd22",
+      "value": {
+        "__attribute__": "aws_s3_bucket.this.id",
+        "__name__": "this",
+        "__ref__": "39c89a96-fc65-4b87-918a-12cb6fe1265e",
+        "__type__": "aws_s3_bucket"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/outputs.tf",
+        "label": "lambda_security_group_id",
+        "line_end": 19,
+        "line_start": 16,
+        "path": "module.vpc.output.lambda_security_group_id"
+      },
+      "description": "Security group ID for Lambda functions",
+      "id": "2ce88653-1e62-4279-a9be-a13093ef6e64",
+      "value": {
+        "__attribute__": "aws_security_group.lambda.id",
+        "__name__": "lambda",
+        "__ref__": "c0dfcab2-f26c-4d90-9d2a-c3b2a197e459",
+        "__type__": "aws_security_group"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/outputs.tf",
+        "label": "private_subnet_ids",
+        "line_end": 14,
+        "line_start": 11,
+        "path": "module.vpc.output.private_subnet_ids"
+      },
+      "description": "List of private subnet IDs",
+      "id": "a34e95e9-08e0-4bb4-8806-493b92718d70",
+      "value": [
+        "d28771c4-ad24-4b28-9819-1f2a8bec355e",
+        "c7bdd566-0f77-43ba-b654-12f50289559c"
+      ]
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/outputs.tf",
+        "label": "public_subnet_ids",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.vpc.output.public_subnet_ids"
+      },
+      "description": "List of public subnet IDs",
+      "id": "82b89ab6-0477-4d6b-8d04-42fd3161e969",
+      "value": [
+        "656c0f93-9133-4a2b-962c-8123e54371d8",
+        "cda46455-a2a7-4e13-a34f-84fbd87f8a63"
+      ]
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/outputs.tf",
+        "label": "vpc_id",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.vpc.output.vpc_id"
+      },
+      "description": "VPC ID",
+      "id": "e25707a1-8035-49ed-81c1-13b020a75c0d",
+      "value": {
+        "__attribute__": "aws_vpc.this.id",
+        "__name__": "this",
+        "__ref__": "412261b3-d02a-4504-9127-abe62236d13e",
+        "__type__": "aws_vpc"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/waf/outputs.tf",
+        "label": "web_acl_arn",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.waf.output.web_acl_arn"
+      },
+      "description": "ARN of the WAF Web ACL",
+      "id": "73bdc24a-ed12-4c5a-9191-3b52e594fb8a",
+      "value": {
+        "__attribute__": "aws_wafv2_web_acl.this.arn",
+        "__name__": "this",
+        "__ref__": "474e2e51-023b-4ad7-844b-96ec86768402",
+        "__type__": "aws_wafv2_web_acl"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/waf/outputs.tf",
+        "label": "web_acl_id",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.waf.output.web_acl_id"
+      },
+      "description": "ID of the WAF Web ACL",
+      "id": "cc781da1-abb6-43f3-8b5b-b2a5a4dfddbf",
+      "value": {
+        "__attribute__": "aws_wafv2_web_acl.this.id",
+        "__name__": "this",
+        "__ref__": "474e2e51-023b-4ad7-844b-96ec86768402",
+        "__type__": "aws_wafv2_web_acl"
+      }
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/waf/outputs.tf",
+        "label": "web_acl_name",
+        "line_end": 14,
+        "line_start": 11,
+        "path": "module.waf.output.web_acl_name"
+      },
+      "description": "Name of the WAF Web ACL",
+      "id": "ec01b734-e445-4c85-ad52-61309668b24b",
+      "value": {
+        "__attribute__": "aws_wafv2_web_acl.this.name",
+        "__name__": "this",
+        "__ref__": "474e2e51-023b-4ad7-844b-96ec86768402",
+        "__type__": "aws_wafv2_web_acl"
+      }
+    }
+  ],
+  "provider": [
+    {
+      "__tfmeta": {
+        "filename": "provider.tf",
+        "label": "aws",
+        "line_end": 6,
+        "line_start": 1,
+        "path": "provider.aws"
+      },
+      "default_tags": {
+        "__tfmeta": {
+          "filename": "provider.tf",
+          "line_end": 5,
+          "line_start": 3
+        },
+        "id": "9301e322-5388-48ae-a572-926666f6b6e0",
+        "tags": {
+          "Environment": "Development",
+          "Owner": "DevTeam",
+          "Project": "ServerlessApp",
+          "Terraform": "true"
+        }
+      },
+      "id": "28a7765b-c676-4f9d-b84e-f584e4c66a72",
+      "region": "ap-northeast-1"
+    }
+  ],
+  "terraform": [
+    {
+      "__tfmeta": {
+        "filename": "backend.tf",
+        "line_end": 5,
+        "line_start": 1,
+        "path": "terraform"
+      },
+      "backend": {
+        "__tfmeta": {
+          "filename": "backend.tf",
+          "label": "local",
+          "line_end": 4,
+          "line_start": 2
+        },
+        "id": "f091ce37-38f4-4f62-8d02-2de8e0069f6e",
+        "path": "./terraform.tfstate"
+      },
+      "id": "0fe53a5d-a15a-468b-bcfb-f4bfa3aee3fd"
+    },
+    {
+      "__tfmeta": {
+        "filename": "versions.tf",
+        "line_end": 9,
+        "line_start": 1,
+        "path": "terraform"
+      },
+      "id": "78ceaa6e-d1b6-4b75-9dd6-d100cd6f65c4",
+      "required_providers": {
+        "__tfmeta": {
+          "filename": "versions.tf",
+          "line_end": 8,
+          "line_start": 3
+        },
+        "aws": {
+          "source": "hashicorp/aws",
+          "version": "~> 5.0"
+        },
+        "id": "9ced50b9-df5f-433a-904d-e46f62142aac"
+      },
+      "required_version": ">= 1.4.0"
+    }
+  ],
+  "variable": [
+    {
+      "__tfmeta": {
+        "filename": "variables.tf",
+        "label": "aws_region",
+        "line_end": 5,
+        "line_start": 1,
+        "path": "variable.aws_region"
+      },
+      "default": "ap-northeast-1",
+      "description": "AWS region to deploy resources",
+      "id": "47988292-1e88-4fa6-aa6c-857be9a59ad5",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/variables.tf",
+        "label": "environment",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.api_gateway.variable.environment"
+      },
+      "description": "Environment name",
+      "id": "7a3107ca-1f43-4a38-aa1e-75a34140e849",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/variables.tf",
+        "label": "lambda_function_name",
+        "line_end": 14,
+        "line_start": 11,
+        "path": "module.api_gateway.variable.lambda_function_name"
+      },
+      "description": "Name of the Lambda function",
+      "id": "edf4ffba-1fe3-44bd-9503-7c9fd72d23b5",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/variables.tf",
+        "label": "lambda_invoke_arn",
+        "line_end": 19,
+        "line_start": 16,
+        "path": "module.api_gateway.variable.lambda_invoke_arn"
+      },
+      "description": "Invoke ARN of the Lambda function",
+      "id": "629d4f8c-b93e-4fde-97f0-aed14a10617d",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/variables.tf",
+        "label": "project",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.api_gateway.variable.project"
+      },
+      "description": "Project name",
+      "id": "a7b80b5b-667d-4e4d-a9f2-01f513adc931",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/api_gateway/variables.tf",
+        "label": "tags",
+        "line_end": 25,
+        "line_start": 21,
+        "path": "module.api_gateway.variable.tags"
+      },
+      "default": {},
+      "description": "Tags to apply to resources",
+      "id": "7339a7aa-29d8-4c6a-849d-8344c2a14d0f",
+      "type": "map of string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/dynamodb/variables.tf",
+        "label": "environment",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.dynamodb.variable.environment"
+      },
+      "description": "Environment name",
+      "id": "c256e09e-af26-4e82-bead-b492b161990e",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/dynamodb/variables.tf",
+        "label": "project",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.dynamodb.variable.project"
+      },
+      "description": "Project name",
+      "id": "0d00d593-ef62-4292-884a-dc4fae25554f",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/dynamodb/variables.tf",
+        "label": "read_capacity",
+        "line_end": 15,
+        "line_start": 11,
+        "path": "module.dynamodb.variable.read_capacity"
+      },
+      "default": 5,
+      "description": "Read capacity units for the DynamoDB table",
+      "id": "78805f83-bc94-4d6e-9059-18820ffd903f",
+      "type": "number"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/dynamodb/variables.tf",
+        "label": "tags",
+        "line_end": 27,
+        "line_start": 23,
+        "path": "module.dynamodb.variable.tags"
+      },
+      "default": {},
+      "description": "Tags to apply to resources",
+      "id": "5b223241-eba3-4ffa-8ba0-cd81db9197bd",
+      "type": "map of string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/dynamodb/variables.tf",
+        "label": "write_capacity",
+        "line_end": 21,
+        "line_start": 17,
+        "path": "module.dynamodb.variable.write_capacity"
+      },
+      "default": 5,
+      "description": "Write capacity units for the DynamoDB table",
+      "id": "b68f766a-e67c-4590-bf19-2dcc50677aa7",
+      "type": "number"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/iam/variables.tf",
+        "label": "environment",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.iam.variable.environment"
+      },
+      "description": "Environment name",
+      "id": "76fad868-0aa2-431a-bf56-45bc86fbc649",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/iam/variables.tf",
+        "label": "project",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.iam.variable.project"
+      },
+      "description": "Project name",
+      "id": "f71f5f5f-0d1a-4e75-84cb-98316a52951d",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/iam/variables.tf",
+        "label": "tags",
+        "line_end": 15,
+        "line_start": 11,
+        "path": "module.iam.variable.tags"
+      },
+      "default": {},
+      "description": "Tags to apply to resources",
+      "id": "bb8456ee-c2c2-44d1-84d5-5d51cdd2f340",
+      "type": "map of string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/variables.tf",
+        "label": "dynamodb_table_arn",
+        "line_end": 57,
+        "line_start": 54,
+        "path": "module.lambda.variable.dynamodb_table_arn"
+      },
+      "description": "ARN of the DynamoDB table",
+      "id": "ddb0bff4-5f2f-4010-bf7f-8a9158c0fe78",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/variables.tf",
+        "label": "dynamodb_table_name",
+        "line_end": 52,
+        "line_start": 49,
+        "path": "module.lambda.variable.dynamodb_table_name"
+      },
+      "description": "Name of the DynamoDB table",
+      "id": "90478d45-a36a-4501-a236-362ec9f7115e",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/variables.tf",
+        "label": "environment",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.lambda.variable.environment"
+      },
+      "description": "Environment name",
+      "id": "df20db45-af00-4662-a924-1ac0c62e8079",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/variables.tf",
+        "label": "lambda_role_arn",
+        "line_end": 24,
+        "line_start": 21,
+        "path": "module.lambda.variable.lambda_role_arn"
+      },
+      "description": "ARN of the IAM role for Lambda",
+      "id": "3ea95312-d012-4c28-980d-984fe1a982c6",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/variables.tf",
+        "label": "lambda_runtime",
+        "line_end": 35,
+        "line_start": 31,
+        "path": "module.lambda.variable.lambda_runtime"
+      },
+      "default": "nodejs18.x",
+      "description": "Runtime for Lambda function",
+      "id": "2724fdb3-c5b0-4fe1-95a6-55276ac58f3f",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/variables.tf",
+        "label": "memory_size",
+        "line_end": 41,
+        "line_start": 37,
+        "path": "module.lambda.variable.memory_size"
+      },
+      "default": 128,
+      "description": "Memory size for Lambda function in MB",
+      "id": "9a9b1638-0c8e-42b2-a20a-38f6e89cb11d",
+      "type": "number"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/variables.tf",
+        "label": "project",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.lambda.variable.project"
+      },
+      "description": "Project name",
+      "id": "d3fff18d-f80c-49bc-ac19-f77f45e8a908",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/variables.tf",
+        "label": "s3_bucket_name",
+        "line_end": 29,
+        "line_start": 26,
+        "path": "module.lambda.variable.s3_bucket_name"
+      },
+      "description": "Name of the S3 bucket for Lambda code",
+      "id": "33d1b595-20b6-4bd6-83dc-cf2e646c575f",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/variables.tf",
+        "label": "subnet_ids",
+        "line_end": 19,
+        "line_start": 16,
+        "path": "module.lambda.variable.subnet_ids"
+      },
+      "description": "Subnet IDs where Lambda will be deployed",
+      "id": "7b247325-0ab3-4a0e-9d1b-e523360ea0ba",
+      "type": "list of string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/variables.tf",
+        "label": "tags",
+        "line_end": 63,
+        "line_start": 59,
+        "path": "module.lambda.variable.tags"
+      },
+      "default": {},
+      "description": "Tags to apply to resources",
+      "id": "d7fe96a4-cff4-49e3-b1ab-0c45d304f8a5",
+      "type": "map of string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/variables.tf",
+        "label": "timeout",
+        "line_end": 47,
+        "line_start": 43,
+        "path": "module.lambda.variable.timeout"
+      },
+      "default": 10,
+      "description": "Timeout for Lambda function in seconds",
+      "id": "22707374-0eef-42d6-a300-2c6c5c701869",
+      "type": "number"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/lambda/variables.tf",
+        "label": "vpc_id",
+        "line_end": 14,
+        "line_start": 11,
+        "path": "module.lambda.variable.vpc_id"
+      },
+      "description": "VPC ID where Lambda will be deployed",
+      "id": "97ad4df5-c912-4cc7-a7d4-0957937d6600",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/s3/variables.tf",
+        "label": "environment",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.s3.variable.environment"
+      },
+      "description": "Environment name",
+      "id": "885b6da0-1afc-4ef0-910d-b2624dd7111b",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/s3/variables.tf",
+        "label": "force_destroy",
+        "line_end": 15,
+        "line_start": 11,
+        "path": "module.s3.variable.force_destroy"
+      },
+      "default": false,
+      "description": "Whether to force destroy the bucket even if it contains objects",
+      "id": "8fcc9f91-1e18-4d24-b890-0fe233faaa01",
+      "type": "bool"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/s3/variables.tf",
+        "label": "project",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.s3.variable.project"
+      },
+      "description": "Project name",
+      "id": "9497df85-96e8-4c93-a157-ed45f3d5f157",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/s3/variables.tf",
+        "label": "tags",
+        "line_end": 21,
+        "line_start": 17,
+        "path": "module.s3.variable.tags"
+      },
+      "default": {},
+      "description": "Tags to apply to resources",
+      "id": "94645f35-609c-4635-b07b-cc58e9e8aeb6",
+      "type": "map of string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/variables.tf",
+        "label": "environment",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.vpc.variable.environment"
+      },
+      "description": "Environment name",
+      "id": "56eb9370-32fa-4fae-b676-1c477176863e",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/variables.tf",
+        "label": "private_subnet_cidrs",
+        "line_end": 24,
+        "line_start": 21,
+        "path": "module.vpc.variable.private_subnet_cidrs"
+      },
+      "description": "CIDR blocks for the private subnets",
+      "id": "6af45eb8-1098-4b2f-8bac-a6f194f2a4b5",
+      "type": "list of string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/variables.tf",
+        "label": "project",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.vpc.variable.project"
+      },
+      "description": "Project name",
+      "id": "27116f84-93fc-418f-821d-50d301ceec12",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/variables.tf",
+        "label": "public_subnet_cidrs",
+        "line_end": 19,
+        "line_start": 16,
+        "path": "module.vpc.variable.public_subnet_cidrs"
+      },
+      "description": "CIDR blocks for the public subnets",
+      "id": "8e85bb1f-91f9-40d8-b307-15b65824f8c2",
+      "type": "list of string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/variables.tf",
+        "label": "tags",
+        "line_end": 30,
+        "line_start": 26,
+        "path": "module.vpc.variable.tags"
+      },
+      "default": {},
+      "description": "Tags to apply to resources",
+      "id": "caa89eaf-9476-4588-9495-0b0f16536f27",
+      "type": "map of string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/vpc/variables.tf",
+        "label": "vpc_cidr",
+        "line_end": 14,
+        "line_start": 11,
+        "path": "module.vpc.variable.vpc_cidr"
+      },
+      "description": "CIDR block for the VPC",
+      "id": "b7785877-08e8-4015-ba77-3220bab259ca",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/waf/variables.tf",
+        "label": "api_gateway_id",
+        "line_end": 14,
+        "line_start": 11,
+        "path": "module.waf.variable.api_gateway_id"
+      },
+      "description": "ID of the API Gateway",
+      "id": "1564926c-bec9-40a4-bf76-17d40436f280",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/waf/variables.tf",
+        "label": "environment",
+        "line_end": 9,
+        "line_start": 6,
+        "path": "module.waf.variable.environment"
+      },
+      "description": "Environment name",
+      "id": "d5521496-5059-4f06-b03e-fc7d35a6b70f",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/waf/variables.tf",
+        "label": "project",
+        "line_end": 4,
+        "line_start": 1,
+        "path": "module.waf.variable.project"
+      },
+      "description": "Project name",
+      "id": "ff2fb21f-96cf-4ef8-989e-6a70b2a60990",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/waf/variables.tf",
+        "label": "stage_name",
+        "line_end": 19,
+        "line_start": 16,
+        "path": "module.waf.variable.stage_name"
+      },
+      "description": "Stage name of the API Gateway",
+      "id": "493f1dee-c442-4e99-a003-0a31938d0c56",
+      "type": "string"
+    },
+    {
+      "__tfmeta": {
+        "filename": "../../modules/waf/variables.tf",
+        "label": "tags",
+        "line_end": 25,
+        "line_start": 21,
+        "path": "module.waf.variable.tags"
+      },
+      "default": {},
+      "description": "Tags to apply to resources",
+      "id": "0afbd113-dd2b-4a8d-8d86-81cc567d5d32",
+      "type": "map of string"
+    }
+  ]
+}

--- a/terraform_samples/serverless/environments/dev/.terraform.lock.hcl
+++ b/terraform_samples/serverless/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.0"
+  hashes = [
+    "h1:1niS9AcwxN8CrWemnJS2Xf6vM72+48Xh3xFSS3DFWQo=",
+    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
+    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
+    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
+    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
+    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
+    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
+    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
+    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
+    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
+    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.90.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:cJ3ab7uBP0NmD+LzxHK63ZG1o9nIppAjt6c0OafGKPw=",
+    "zh:0ed246595c4ffb3ea3649528ff171503db208fb20be5f750b8e359d17ee72b60",
+    "zh:1d5c500913b5df0fbf5e8143354aecc736cc4e66d58d4ab17deb24b721ab743a",
+    "zh:337f3511335e6e32431548913d1973ae077d1a4c2f77677675c92c60cd2f5e0a",
+    "zh:624762ff78819aee434d6c3e6c79eb93c91060be2df4f45f9014272a60b5d608",
+    "zh:7f4ab9bcd667e38b7d7b7aa1068535f01eef3656ecd422acccbe8238d377a15a",
+    "zh:84542ce0403cacee245c1a159169cc0ddb965d7d734216f9eb0bb3ff0a0bae36",
+    "zh:85dd27e39f2c3ab13cb5c02236b810893bd90ec6da33fabaa7ab6d116accfa10",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a0cf76959ade91958b08d186f5bcdc403395fa635f21912464da40bc7a5db4ff",
+    "zh:a9a48f9f7f4122b6a44b7273b4cc54020887f7346f50286d7da1278cca2ee952",
+    "zh:c119b826e334aac2d03ea561774dad536ccd6449e2a4f42b3af100623ae02679",
+    "zh:d4204ca7f1295732660c70db4ea04c3ae1f7e1ac82c0ec9d0dc549493bc45e7a",
+    "zh:d95f89181d12ebab1b1f964274d29795e1e6e2d112ea97caffd8a7f1326a922d",
+    "zh:e529c7be1037f1a9a733fc0bcbbdcc58fc44f85ed343f891e5c584b2ef56fd5c",
+    "zh:e541c135514a6727f20410a9a52c06cb71b4ddadaf2a41da28d599fb1c442845",
+  ]
+}

--- a/terraform_samples/serverless/environments/dev/backend.tf
+++ b/terraform_samples/serverless/environments/dev/backend.tf
@@ -1,9 +1,5 @@
 terraform {
-  backend "s3" {
-    bucket         = "serverless-app-terraform-state"
-    key            = "dev/terraform.tfstate"
-    region         = "ap-northeast-1"
-    encrypt        = true
-    dynamodb_table = "terraform-state-lock"
+  backend "local" {
+    path = "./terraform.tfstate"
   }
 }


### PR DESCRIPTION
## 変更内容
- Terraformのバックエンド設定をローカルファイルシステムに変更
- terraform.tfstateをローカルに保存するよう設定
- 関連する.terraform.lock.hclファイルを追加
- custom_outputディレクトリの追加

## 目的
ローカル環境での開発とテストを容易にするため、Terraformの状態をローカルに保存する設定に変更しました。